### PR TITLE
Enable SVS factory format

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -103,9 +103,9 @@ set(FAISS_SRC
 if(FAISS_ENABLE_SVS)
   list(APPEND FAISS_SRC
     IndexSVSFlat.cpp
-    IndexSVS.cpp
-    IndexSVSLVQ.cpp
-    IndexSVSLeanVec.cpp
+    IndexSVSVamana.cpp
+    IndexSVSVamanaLVQ.cpp
+    IndexSVSVamanaLeanVec.cpp
     impl/svs_io.cpp
   )
 endif()
@@ -254,9 +254,9 @@ set(FAISS_HEADERS
 if(FAISS_ENABLE_SVS)
   list(APPEND FAISS_HEADERS
     IndexSVSFlat.h
-    IndexSVS.h
-    IndexSVSLVQ.h
-    IndexSVSLeanVec.h
+    IndexSVSVamana.h
+    IndexSVSVamanaLVQ.h
+    IndexSVSVamanaLeanVec.h
   )
 endif()
 

--- a/faiss/IndexSVSVamana.h
+++ b/faiss/IndexSVSVamana.h
@@ -20,21 +20,21 @@ class DynamicVamana;
 
 namespace faiss {
 
-struct IndexSVS : Index {
-    size_t graph_max_degree = 64;
+struct IndexSVSVamana : Index {
+    size_t graph_max_degree;
+    size_t prune_to;
     float alpha = 1.2;
     size_t search_window_size = 10;
     size_t search_buffer_capacity = 10;
     size_t construction_window_size = 40;
     size_t max_candidate_pool_size = 200;
-    size_t prune_to = 60;
     bool use_full_search_history = true;
 
-    IndexSVS();
+    IndexSVSVamana();
 
-    IndexSVS(idx_t d, MetricType metric = METRIC_L2);
+    IndexSVSVamana(idx_t d, size_t degree, MetricType metric = METRIC_L2);
 
-    virtual ~IndexSVS() override;
+    virtual ~IndexSVSVamana() override;
 
     void add(idx_t n, const float* x) override;
 

--- a/faiss/IndexSVSVamanaLVQ.h
+++ b/faiss/IndexSVSVamanaLVQ.h
@@ -7,15 +7,15 @@
 
 #pragma once
 
-#include <faiss/IndexSVS.h>
+#include <faiss/IndexSVSVamana.h>
 
 #include <svs/extensions/vamana/lvq.h>
 
 namespace faiss {
 
-enum LVQLevel { LVQ_4x0, LVQ_4x4, LVQ_4x8 };
+enum LVQLevel { LVQ4x0, LVQ4x4, LVQ4x8 };
 
-struct IndexSVSLVQ : IndexSVS {
+struct IndexSVSVamanaLVQ : IndexSVSVamana {
     using blocked_alloc_type =
             svs::data::Blocked<svs::lib::Allocator<std::byte>>;
 
@@ -28,13 +28,14 @@ struct IndexSVSLVQ : IndexSVS {
     using storage_type_4x8 = svs::quantization::lvq::
             LVQDataset<4, 8, svs::Dynamic, strategy_type_4, blocked_alloc_type>;
 
-    IndexSVSLVQ() = default;
-    IndexSVSLVQ(
+    IndexSVSVamanaLVQ() = default;
+    IndexSVSVamanaLVQ(
             idx_t d,
+            size_t degree,
             MetricType metric = METRIC_L2,
-            LVQLevel lvq_level = LVQLevel::LVQ_4x4);
+            LVQLevel lvq_level = LVQLevel::LVQ4x4);
 
-    ~IndexSVSLVQ() override = default;
+    ~IndexSVSVamanaLVQ() override = default;
 
     void init_impl(idx_t n, const float* x) override;
 

--- a/faiss/IndexSVSVamanaLeanVec.h
+++ b/faiss/IndexSVSVamanaLeanVec.h
@@ -7,15 +7,15 @@
 
 #pragma once
 
-#include <faiss/IndexSVS.h>
+#include <faiss/IndexSVSVamana.h>
 
 #include <svs/extensions/vamana/leanvec.h>
 
 namespace faiss {
 
-enum LeanVecLevel { LeanVec_4x4, LeanVec_4x8, LeanVec_8x8 };
+enum LeanVecLevel { LeanVec4x4, LeanVec4x8, LeanVec8x8 };
 
-struct IndexSVSLeanVec : IndexSVS {
+struct IndexSVSVamanaLeanVec : IndexSVSVamana {
     using blocked_alloc_type =
             svs::data::Blocked<svs::lib::Allocator<std::byte>>;
     using storage_type_4x4 = svs::leanvec::LeanDataset<
@@ -37,15 +37,16 @@ struct IndexSVSLeanVec : IndexSVS {
             svs::Dynamic,
             blocked_alloc_type>;
 
-    IndexSVSLeanVec() = default;
+    IndexSVSVamanaLeanVec() = default;
 
-    IndexSVSLeanVec(
+    IndexSVSVamanaLeanVec(
             idx_t d,
+            size_t degree,
             MetricType metric = METRIC_L2,
             size_t leanvec_dims = 0,
-            LeanVecLevel leanvec_level = LeanVecLevel::LeanVec_4x4);
+            LeanVecLevel leanvec_level = LeanVecLevel::LeanVec4x4);
 
-    ~IndexSVSLeanVec() override = default;
+    ~IndexSVSVamanaLeanVec() override = default;
 
     void reset() override;
 

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -46,10 +46,10 @@
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #ifdef FAISS_ENABLE_SVS
-#include <faiss/IndexSVS.h>
 #include <faiss/IndexSVSFlat.h>
-#include <faiss/IndexSVSLVQ.h>
-#include <faiss/IndexSVSLeanVec.h>
+#include <faiss/IndexSVSVamana.h>
+#include <faiss/IndexSVSVamanaLVQ.h>
+#include <faiss/IndexSVSVamanaLeanVec.h>
 #endif
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/MetaIndexes.h>
@@ -1252,13 +1252,15 @@ Index* read_index(IOReader* f, int io_flags) {
 #ifdef FAISS_ENABLE_SVS
     else if (
             h == fourcc("ILVQ") || h == fourcc("ISVL") || h == fourcc("ISVD")) {
-        IndexSVS* svs;
+        // Vamana
+        IndexSVSVamana* svs;
         if (h == fourcc("ILVQ")) {
-            svs = new IndexSVSLVQ(); // LVQ
+            svs = new IndexSVSVamanaLVQ(); // Vamana LVQ
         } else if (h == fourcc("ISVL")) {
-            svs = new IndexSVSLeanVec(); // LeanVec
+            svs = new IndexSVSVamanaLeanVec(); // Vamana LeanVec
         } else if (h == fourcc("ISVD")) {
-            svs = new IndexSVS(); // uncompressed
+            svs = new IndexSVSVamana(); // public SVS datatypes including fp32,
+                                        // fp16, and SQ8
         }
 
         read_index_header(svs, f);
@@ -1271,11 +1273,11 @@ Index* read_index(IOReader* f, int io_flags) {
         READ1(svs->prune_to);
         READ1(svs->use_full_search_history);
         if (h == fourcc("ILVQ")) {
-            READ1(dynamic_cast<IndexSVSLVQ*>(svs)->lvq_level);
+            READ1(dynamic_cast<IndexSVSVamanaLVQ*>(svs)->lvq_level);
         }
         if (h == fourcc("ISVL")) {
-            READ1(dynamic_cast<IndexSVSLeanVec*>(svs)->leanvec_d);
-            READ1(dynamic_cast<IndexSVSLeanVec*>(svs)->leanvec_level);
+            READ1(dynamic_cast<IndexSVSVamanaLeanVec*>(svs)->leanvec_d);
+            READ1(dynamic_cast<IndexSVSVamanaLeanVec*>(svs)->leanvec_level);
         }
 
         faiss::BufferedIOReader br(f);

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -44,10 +44,10 @@
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #ifdef FAISS_ENABLE_SVS
-#include <faiss/IndexSVS.h>
 #include <faiss/IndexSVSFlat.h>
-#include <faiss/IndexSVSLVQ.h>
-#include <faiss/IndexSVSLeanVec.h>
+#include <faiss/IndexSVSVamana.h>
+#include <faiss/IndexSVSVamanaLVQ.h>
+#include <faiss/IndexSVSVamanaLeanVec.h>
 #endif
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/MetaIndexes.h>
@@ -889,7 +889,9 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         write_InvertedLists(ivrq->invlists, f);
     }
 #ifdef FAISS_ENABLE_SVS
-    else if (const IndexSVS* svs = dynamic_cast<const IndexSVS*>(idx)) {
+    else if (
+            const IndexSVSVamana* svs =
+                    dynamic_cast<const IndexSVSVamana*>(idx)) {
         // The SVS implementation will write its contents to three directories,
         // which we will read back here for writing to the actual output file.
         // To avoid a full copy of the index in memory, we stream chunks.
@@ -900,8 +902,8 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         // assume EOF means end of binary SVS blobl.
 
         uint32_t h;
-        auto* lvq = dynamic_cast<const IndexSVSLVQ*>(svs);
-        auto* lean = dynamic_cast<const IndexSVSLeanVec*>(svs);
+        auto* lvq = dynamic_cast<const IndexSVSVamanaLVQ*>(svs);
+        auto* lean = dynamic_cast<const IndexSVSVamanaLeanVec*>(svs);
         if (lvq != nullptr) {
             h = fourcc("ILVQ"); // LVQ
         } else if (lean != nullptr) {

--- a/faiss/impl/svs_io.cpp
+++ b/faiss/impl/svs_io.cpp
@@ -48,7 +48,7 @@ std::streambuf::int_type ReaderStreambuf::underflow() {
     }
     size_t got = (*r)(buf.data(), 1, buf.size());
     if (got == 0) {
-        return traits_type::eof(); 
+        return traits_type::eof();
     }
     setg(buf.data(), buf.data(), buf.data() + got);
     return traits_type::to_int_type(*gptr());

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -219,7 +219,7 @@ add_ref_in_constructor(IDSelectorXOr, slice(2))
 add_ref_in_constructor(IndexIVFIndependentQuantizer, slice(3))
 
 if "SVS" in get_compile_options():
-    add_ref_in_constructor(IndexSVS, 0)
+    add_ref_in_constructor(IndexSVSVamana, 0)
     add_ref_in_constructor(IndexSVSFlat, 0)
 
 # seems really marginal...

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -195,10 +195,10 @@ typedef uint64_t size_t;
 #include <faiss/IndexIVFRaBitQ.h>
 
 #ifdef FAISS_ENABLE_SVS
-#include <faiss/IndexSVS.h>
+#include <faiss/IndexSVSVamana.h>
 #include <faiss/IndexSVSFlat.h>
-#include <faiss/IndexSVSLVQ.h>
-#include <faiss/IndexSVSLeanVec.h>
+#include <faiss/IndexSVSVamanaLVQ.h>
+#include <faiss/IndexSVSVamanaLeanVec.h>
 #endif
 
 %}
@@ -693,10 +693,10 @@ struct faiss::simd16uint16 {};
 %ignore faiss::svs_io::WriterStreambuf;
 %ignore faiss::svs_io::SVSTempDirectory;
 
-%include  <faiss/IndexSVS.h>
+%include  <faiss/IndexSVSVamana.h>
 %include  <faiss/IndexSVSFlat.h>
-%include  <faiss/IndexSVSLVQ.h>
-%include  <faiss/IndexSVSLeanVec.h>
+%include  <faiss/IndexSVSVamanaLVQ.h>
+%include  <faiss/IndexSVSVamanaLeanVec.h>
 #endif // FAISS_ENABLE_SVS
 
 #ifdef GPU_WRAPPER
@@ -847,9 +847,9 @@ struct faiss::simd16uint16 {};
     DOWNCAST ( IndexRowwiseMinMaxFP16 )
 #ifdef FAISS_ENABLE_SVS
     DOWNCAST ( IndexSVSFlat )
-    DOWNCAST ( IndexSVSLeanVec )
-    DOWNCAST ( IndexSVSLVQ )
-    DOWNCAST ( IndexSVS )
+    DOWNCAST ( IndexSVSVamanaLeanVec )
+    DOWNCAST ( IndexSVSVamanaLVQ )
+    DOWNCAST ( IndexSVSVamana )
 #endif // FAISS_ENABLE_SVS
 #ifdef GPU_WRAPPER
 #ifdef FAISS_ENABLE_CUVS

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -6,10 +6,10 @@
  */
 
 #include <faiss/Index.h>
-#include <faiss/IndexSVS.h>
+#include <faiss/IndexSVSVamana.h>
 #include <faiss/IndexSVSFlat.h>
-#include <faiss/IndexSVSLVQ.h>
-#include <faiss/IndexSVSLeanVec.h>
+#include <faiss/IndexSVSVamanaLVQ.h>
+#include <faiss/IndexSVSVamanaLeanVec.h>
 #include <faiss/index_io.h>
 #include <gtest/gtest.h>
 #include <type_traits>
@@ -74,13 +74,13 @@ void write_and_read_index(T& index, const std::vector<float>& xb, size_t n) {
     EXPECT_EQ(loaded->max_candidate_pool_size, index.max_candidate_pool_size);
     EXPECT_EQ(loaded->prune_to, index.prune_to);
     EXPECT_EQ(loaded->use_full_search_history, index.use_full_search_history);
-    if constexpr (std::is_same_v<std::decay_t<T>, faiss::IndexSVSLVQ>) {
-        auto* lvq_loaded = dynamic_cast<faiss::IndexSVSLVQ*>(loaded);
+    if constexpr (std::is_same_v<std::decay_t<T>, faiss::IndexSVSVamanaLVQ>) {
+        auto* lvq_loaded = dynamic_cast<faiss::IndexSVSVamanaLVQ*>(loaded);
         ASSERT_NE(lvq_loaded, nullptr);
         EXPECT_EQ(lvq_loaded->lvq_level, index.lvq_level);
     }
-    if constexpr (std::is_same_v<std::decay_t<T>, faiss::IndexSVSLeanVec>) {
-        auto* lvq_loaded = dynamic_cast<faiss::IndexSVSLeanVec*>(loaded);
+    if constexpr (std::is_same_v<std::decay_t<T>, faiss::IndexSVSVamanaLeanVec>) {
+        auto* lvq_loaded = dynamic_cast<faiss::IndexSVSVamanaLeanVec*>(loaded);
         ASSERT_NE(lvq_loaded, nullptr);
         EXPECT_EQ(lvq_loaded->leanvec_level, index.leanvec_level);
     }
@@ -89,48 +89,48 @@ void write_and_read_index(T& index, const std::vector<float>& xb, size_t n) {
 }
 
 TEST_F(SVSIOTest, WriteAndReadIndexSVS) {
-    faiss::IndexSVS index{d};
+    faiss::IndexSVSVamana index{d};
     write_and_read_index(index, test_data, n);
 }
 
 TEST_F(SVSIOTest, WriteAndReadIndexSVSLVQ4x0) {
-    faiss::IndexSVSLVQ index{d};
-    index.lvq_level = faiss::LVQLevel::LVQ_4x0;
+    faiss::IndexSVSVamanaLVQ index{d};
+    index.lvq_level = faiss::LVQLevel::LVQ4x0;
     write_and_read_index(index, test_data, n);
 }
 
 TEST_F(SVSIOTest, WriteAndReadIndexSVSLVQ4x4) {
-    faiss::IndexSVSLVQ index{d};
-    index.lvq_level = faiss::LVQLevel::LVQ_4x4;
+    faiss::IndexSVSVamanaLVQ index{d};
+    index.lvq_level = faiss::LVQLevel::LVQ4x4;
     write_and_read_index(index, test_data, n);
 }
 
 TEST_F(SVSIOTest, WriteAndReadIndexSVSLVQ4x8) {
-    faiss::IndexSVSLVQ index{d};
-    index.lvq_level = faiss::LVQLevel::LVQ_4x8;
+    faiss::IndexSVSVamanaLVQ index{d};
+    index.lvq_level = faiss::LVQLevel::LVQ4x8;
     write_and_read_index(index, test_data, n);
 }
 
-TEST_F(SVSIOTest, WriteAndReadIndexSVSLeanVec4x4) {
-    faiss::IndexSVSLeanVec index{
+TEST_F(SVSIOTest, WriteAndReadIndexSVSVamanaLeanVec4x4) {
+    faiss::IndexSVSVamanaLeanVec index{
             d, faiss::METRIC_L2, 0, faiss::LeanVecLevel::LeanVec_4x4};
     write_and_read_index(index, test_data, n);
 }
 
-TEST_F(SVSIOTest, WriteAndReadIndexSVSLeanVec4x8) {
-    faiss::IndexSVSLeanVec index{
+TEST_F(SVSIOTest, WriteAndReadIndexSVSVamanaLeanVec4x8) {
+    faiss::IndexSVSVamanaLeanVec index{
             d, faiss::METRIC_L2, 0, faiss::LeanVecLevel::LeanVec_4x8};
     write_and_read_index(index, test_data, n);
 }
 
-TEST_F(SVSIOTest, WriteAndReadIndexSVSLeanVec8x8) {
-    faiss::IndexSVSLeanVec index{
+TEST_F(SVSIOTest, WriteAndReadIndexSVSVamanaLeanVec8x8) {
+    faiss::IndexSVSVamanaLeanVec index{
             d, faiss::METRIC_L2, 0, faiss::LeanVecLevel::LeanVec_8x8};
     write_and_read_index(index, test_data, n);
 }
 
 TEST_F(SVSIOTest, LeanVecThrowsWithoutTraining) {
-    faiss::IndexSVSLeanVec index{
+    faiss::IndexSVSVamanaLeanVec index{
             64, faiss::METRIC_L2, 0, faiss::LeanVecLevel::LeanVec_4x4};
     ASSERT_THROW(index.add(100, test_data.data()), faiss::FaissException);
 }

--- a/tutorial/cpp/10-SVS-Vamana.cpp
+++ b/tutorial/cpp/10-SVS-Vamana.cpp
@@ -10,7 +10,8 @@
 #include <cstdlib>
 #include <random>
 
-#include <faiss/IndexSVSLeanVec.h>
+#include <faiss/IndexSVSVamana.h>
+#include <faiss/index_io.h>
 
 using idx_t = faiss::idx_t;
 
@@ -39,15 +40,14 @@ int main() {
 
     int k = 4;
 
-    faiss::IndexSVSLeanVec index(d);
-    index.train(nb, xb);
+    faiss::IndexSVSVamana index(d, 32);
     index.add(nb, xb);
 
     { // search xq
         idx_t* I = new idx_t[k * nq];
         float* D = new float[k * nq];
 
-        index.search(nq, xq, k, D, I);
+        index.search(nq, xb, k, D, I);
 
         printf("I=\n");
         for (int i = nq - 5; i < nq; i++) {
@@ -67,8 +67,44 @@ int main() {
         delete[] D;
     }
 
+    std::cout << "Persisting index to disk and reloading." << std::endl;
+
+    faiss::write_index(&index, "/tmp/test_svs_index.faiss");
+    faiss::IndexSVSVamana* reloaded = dynamic_cast<faiss::IndexSVSVamana*>(
+            faiss::read_index("/tmp/test_svs_index.faiss"));
+    FAISS_THROW_IF_NOT_MSG(reloaded, "Failed to reload index from disk");
+
+    { // search xq
+        idx_t* I = new idx_t[k * nq];
+        float* D = new float[k * nq];
+
+        reloaded->search(nq, xb, k, D, I);
+
+        printf("I=\n");
+        for (int i = nq - 5; i < nq; i++) {
+            for (int j = 0; j < k; j++)
+                printf("%5zd ", I[i * k + j]);
+            printf("\n");
+        }
+
+        printf("D=\n");
+        for (int i = nq - 5; i < nq; i++) {
+            for (int j = 0; j < k; j++)
+                printf("%5f ", D[i * k + j]);
+            printf("\n");
+        }
+
+        delete[] I;
+        delete[] D;
+    }
+
+    delete reloaded;
+
     delete[] xb;
     delete[] xq;
+
+    // delete the temporary file
+    std::remove("/tmp/test_svs_index.faiss");
 
     return 0;
 }

--- a/tutorial/cpp/11-SVS-Vamana-LVQ.cpp
+++ b/tutorial/cpp/11-SVS-Vamana-LVQ.cpp
@@ -10,8 +10,7 @@
 #include <cstdlib>
 #include <random>
 
-#include <faiss/IndexSVS.h>
-#include <faiss/index_io.h>
+#include <faiss/IndexSVSVamanaLVQ.h>
 
 using idx_t = faiss::idx_t;
 
@@ -40,14 +39,14 @@ int main() {
 
     int k = 4;
 
-    faiss::IndexSVS index(d);
+    faiss::IndexSVSVamanaLVQ index(d, 64);
     index.add(nb, xb);
 
     { // search xq
         idx_t* I = new idx_t[k * nq];
         float* D = new float[k * nq];
 
-        index.search(nq, xb, k, D, I);
+        index.search(nq, xq, k, D, I);
 
         printf("I=\n");
         for (int i = nq - 5; i < nq; i++) {
@@ -66,45 +65,9 @@ int main() {
         delete[] I;
         delete[] D;
     }
-
-    std::cout << "Persisting index to disk and reloading." << std::endl;
-
-    faiss::write_index(&index, "/tmp/test_svs_index.faiss");
-    faiss::IndexSVS* reloaded = dynamic_cast<faiss::IndexSVS*>(
-            faiss::read_index("/tmp/test_svs_index.faiss"));
-    FAISS_THROW_IF_NOT_MSG(reloaded, "Failed to reload index from disk");
-
-    { // search xq
-        idx_t* I = new idx_t[k * nq];
-        float* D = new float[k * nq];
-
-        reloaded->search(nq, xb, k, D, I);
-
-        printf("I=\n");
-        for (int i = nq - 5; i < nq; i++) {
-            for (int j = 0; j < k; j++)
-                printf("%5zd ", I[i * k + j]);
-            printf("\n");
-        }
-
-        printf("D=\n");
-        for (int i = nq - 5; i < nq; i++) {
-            for (int j = 0; j < k; j++)
-                printf("%5f ", D[i * k + j]);
-            printf("\n");
-        }
-
-        delete[] I;
-        delete[] D;
-    }
-
-    delete reloaded;
 
     delete[] xb;
     delete[] xq;
-
-    // delete the temporary file
-    std::remove("/tmp/test_svs_index.faiss");
 
     return 0;
 }

--- a/tutorial/cpp/12-SVS-Vamana-LeanVec.cpp
+++ b/tutorial/cpp/12-SVS-Vamana-LeanVec.cpp
@@ -10,7 +10,7 @@
 #include <cstdlib>
 #include <random>
 
-#include <faiss/IndexSVSLVQ.h>
+#include <faiss/IndexSVSVamanaLeanVec.h>
 
 using idx_t = faiss::idx_t;
 
@@ -39,7 +39,8 @@ int main() {
 
     int k = 4;
 
-    faiss::IndexSVSLVQ index(d);
+    faiss::IndexSVSVamanaLeanVec index(d, 32);
+    index.train(nb, xb);
     index.add(nb, xb);
 
     { // search xq

--- a/tutorial/cpp/CMakeLists.txt
+++ b/tutorial/cpp/CMakeLists.txt
@@ -31,14 +31,14 @@ add_executable(9-RefineComparison EXCLUDE_FROM_ALL 9-RefineComparison.cpp)
 target_link_libraries(9-RefineComparison PRIVATE faiss)
 
 if(FAISS_ENABLE_SVS)
-  add_executable(10-SVS EXCLUDE_FROM_ALL 10-SVS.cpp)
-  target_link_libraries(10-SVS PRIVATE faiss)
+  add_executable(10-SVS-Vamana EXCLUDE_FROM_ALL 10-SVS-Vamana.cpp)
+  target_link_libraries(10-SVS-Vamana PRIVATE faiss)
 
-  add_executable(11-SVSLVQ EXCLUDE_FROM_ALL 11-SVSLVQ.cpp)
-  target_link_libraries(11-SVSLVQ PRIVATE faiss)
+  add_executable(11-SVS-Vamana-LVQ EXCLUDE_FROM_ALL 11-SVS-Vamana-LVQ.cpp)
+  target_link_libraries(11-SVS-Vamana-LVQ PRIVATE faiss)
 
-  add_executable(12-SVSLeanVec EXCLUDE_FROM_ALL 12-SVSLeanVec.cpp)
-  target_link_libraries(12-SVSLeanVec PRIVATE faiss)
+  add_executable(12-SVS-Vamana-LeanVec EXCLUDE_FROM_ALL 12-SVS-Vamana-LeanVec.cpp)
+  target_link_libraries(12-SVS-Vamana-LeanVec PRIVATE faiss)
 
   add_executable(13-tmp-svscomp EXCLUDE_FROM_ALL 13-tmp-svscomp.cpp)
   target_link_libraries(13-tmp-svscomp PRIVATE faiss)

--- a/tutorial/python/10-SVS.py
+++ b/tutorial/python/10-SVS.py
@@ -15,11 +15,7 @@ xq = np.random.random((nq, d)).astype('float32')
 xq[:, 0] += np.arange(nq) / 1000.
 
 import faiss                        # make faiss available
-index = faiss.IndexSVS(d)           # build the index (DynamicVamana, float32)
-
-# index = faiss.IndexSVSFlat(d)     # build the SVSFlat index
-# index = faiss.IndexSVSLVQ(d)      # build the SVSLVQ index, quantization parameters
-# index = faiss.IndexSVSLeanVec(d)   # build the SVSLeanVec index, quantization parameters
+index = faiss.IndexSVSVamana(d, 64)           # build the index (DynamicVamana, float32)
 
 print(index.is_trained)
 index.add(xb)                  # add vectors to the index
@@ -46,14 +42,27 @@ print(I[:5])                   # neighbors of the 5 first queries
 print(f"{k} nearest neighbors of the 5 last query vectors (after reloading)")
 print(I[-5:])                  # neighbors of the 5 last queries
 
-lvq_idx = faiss.IndexSVSLVQ(d, faiss.METRIC_L2, faiss.LVQ_4x8) # example of using SVS LVQ
-lvq_idx_fac = faiss.index_factory(d, 'SVS_LVQ_4x8', faiss.METRIC_L2) # example of using factory for SVS LVQ
-lvq_idx_fac.add(xb)
-lvq_idx_fac.search(xq, k)
+flat_idx_fac = faiss.index_factory(d, 'SVS,Flat', faiss.METRIC_L2) # example of using factory for SVS Flat
+flat_idx_fac.add(xb)
+flat_idx_fac.search(xq, k)
+
+uncompressed_idx_fac = faiss.index_factory(d, 'SVS,Vamana64', faiss.METRIC_L2) # example of using factory for SVS Vamana uncompressed
+uncompressed_idx_fac.add(xb)
+uncompressed_idx_fac.search(xq, k)
+
+lvq_idx = faiss.IndexSVSVamanaLVQ(d, faiss.METRIC_L2, faiss.LVQ4x8) # example of using SVS Vamana uncompressed
+lvq_idx_fac_2 = faiss.index_factory(d, 'SVS,Vamana32,LVQ4x4', faiss.METRIC_L2) # example of using factory for SVS Vamana LVQ
+lvq_idx_fac_2.add(xb)
+lvq_idx_fac_2.search(xq, k)
 
 
-leanvec_idx = faiss.IndexSVSLeanVec(d, faiss.METRIC_L2, 0, faiss.LeanVec_4x4) # example of using SVS LeanVec
-leanvec_idx_fac = faiss.index_factory(d, 'SVS_LeanVec_4x4,32', faiss.METRIC_L2) # example of using factory for SVS LeanVec
+leanvec_idx = faiss.IndexSVSVamanaLeanVec(d, faiss.METRIC_L2, 0, faiss.LeanVec4x4) # example of using SVS Vamana LeanVec
+leanvec_idx_fac = faiss.index_factory(d, 'SVS,Vamana32,LeanVec4x4', faiss.METRIC_L2) # example of using factory for SVS Vamana LeanVec
 leanvec_idx_fac.train(xb)
 leanvec_idx_fac.add(xb)
 leanvec_idx_fac.search(xq, k)
+
+leanvec_idx_fac2 = faiss.index_factory(d, 'SVS,Vamana64,LeanVec4x4_16', faiss.METRIC_L2) # example of using factory for SVS Vamana LeanVec. leanvec_dim is 16
+leanvec_idx_fac2.train(xb)
+leanvec_idx_fac2.add(xb)
+leanvec_idx_fac2.search(xq, k)


### PR DESCRIPTION
This PR enable SVS factory format that follows the following logic:
<img width="1864" height="595" alt="image" src="https://github.com/user-attachments/assets/2c8b542c-e310-4113-a661-e190af516856" />

Examples: 
- SVS,Vamana32,LVQ4x4
- SVS,Flat
- SVS,Vamana64,LeanVec8x8_16


Changes required:
- Rename SVS classes. Now `IndexSVS*` is changed to `IndexSVSVamana*`
- Add `graph_max_degree` parameter in the SVS constructor. This is the most important parameter. Adding this parameter also matches `FaissHNSW` constructor that has `M` parameter.
- Remove `_` in LVQ and LeanVec level. That is, `LVQ_4x4` becomes `LVQ4x4`

